### PR TITLE
Novo Layout da Caixa SIGCB CNAB 240

### DIFF
--- a/src/Cnab/Factory.php
+++ b/src/Cnab/Factory.php
@@ -4,6 +4,7 @@ namespace Cnab;
 class Factory
 {
     private static $cnabFormatPath = null;
+    private static $layout_versao = null;
 
     public static function getCnabFormatPath() {
         if (self::$cnabFormatPath === null) {
@@ -24,6 +25,23 @@ class Factory
 
     public static function setCnabFormatPath($value) {
         self::$cnabFormatPath = $value;
+    }
+
+    public static function getLayoutVersao($filename = null)
+    {
+        if(self::$layout_versao === null && $filename != null)
+        {
+            $identifier = new Format\Identifier;
+            $format = $identifier->identifyFile($filename);
+
+            self::$layout_versao = $format['layout_versao'];
+        }
+
+        return self::$layout_versao;
+    }
+
+    public static function setLayoutVersao($value) {
+        self::$layout_versao = $value;
     }
 
 	/**

--- a/src/Cnab/Format/Identifier.php
+++ b/src/Cnab/Format/Identifier.php
@@ -37,6 +37,8 @@ class Identifier
             $codigo_banco = \substr($lines[0], 76, 3);
             $codigo_tipo  = \substr($lines[0],  1, 1);
             $tipo = null;
+            $layout_versao = null;
+
             if($codigo_tipo == '1')
                 $tipo = 'remessa';
             else if ($codigo_tipo == '2')
@@ -47,6 +49,24 @@ class Identifier
             $codigo_banco = \substr($lines[0], 0, 3);
             $codigo_tipo  = \substr($lines[0],  142, 1);
             $tipo = null;
+            $layout_versao = null;
+
+            // Pega a Versao do Layout da CEF 
+            if(\Cnab\Banco::CEF == $codigo_banco)
+            {
+                $layout_versao = \substr($lines[0], 163, 3);
+
+                if($layout_versao == '040' || $layout_versao == '050')
+                {
+                    $layout_versao = 'SIGCB';
+                }
+                else
+                {
+                    // Layout SICOB
+                    $layout_versao = null;
+                }
+            }
+
             if(\strtoupper($codigo_tipo) == '1')
                 $tipo = 'remessa';
             elseif (\strtoupper($codigo_tipo) == '2')
@@ -59,6 +79,7 @@ class Identifier
             'banco' => $codigo_banco,
             'tipo'  => $tipo,
             'bytes' => $bytes,
+            'layout_versao' => $layout_versao,
         );
 
         return $result;

--- a/src/Cnab/Format/Identifier.php
+++ b/src/Cnab/Format/Identifier.php
@@ -58,7 +58,8 @@ class Identifier
 
                 if($layout_versao == '040' || $layout_versao == '050')
                 {
-                    $layout_versao = 'SIGCB';
+                    // Layout SIGCB
+                    $layout_versao = 'sigcb';
                 }
                 else
                 {

--- a/src/Cnab/Format/YamlLoad.php
+++ b/src/Cnab/Format/YamlLoad.php
@@ -100,7 +100,7 @@ class YamlLoad
         if($layout_versao != null)
         {
             // Usado quando o banco possuir mais de uma versao de Layout
-            $filenameEspecifico = $this->formatPath.'/'.$cnab.'/'.$banco.'/'.$layout_versao.'_'.$filename.'.yml';
+            $filenameEspecifico = $this->formatPath.'/'.$cnab.'/'.$banco.'/'.$layout_versao.'/'.$filename.'.yml';
         }
 
         if(!file_exists($filenamePadrao) && !file_exists($filenameEspecifico))
@@ -120,7 +120,8 @@ class YamlLoad
         return $arrayFormat;
     }
 
-    public function load(Linha $cnabLinha, $cnab, $filename) {
+    public function load(Linha $cnabLinha, $cnab, $filename)
+    {
         $arrayFormat = $this->loadFormat($cnab, $filename);
         $this->loadArray($cnabLinha, $arrayFormat);
     }

--- a/src/Cnab/Format/YamlLoad.php
+++ b/src/Cnab/Format/YamlLoad.php
@@ -6,9 +6,10 @@ use Cnab\Factory;
 class YamlLoad
 {
     public $codigo_banco = null;
+    public $layout_versao = null;
     public $formatPath;
 
-    public function __construct($codigo_banco)
+    public function __construct($codigo_banco, $layout_versao = null)
     {
         $this->codigo_banco = $codigo_banco;
         $this->formatPath = Factory::getCnabFormatPath();
@@ -94,6 +95,12 @@ class YamlLoad
         $banco = sprintf('%03d', $this->codigo_banco);
         $filenamePadrao = $this->formatPath.'/'.$cnab.'/generic/'.$filename.'.yml';
         $filenameEspecifico = $this->formatPath.'/'.$cnab.'/'.$banco.'/'.$filename.'.yml';
+
+        if($this->layout_versao != null)
+        {
+            // Usado quando o banco possuir mais de uma versao de Layout
+            $filenameEspecifico = $this->formatPath.'/'.$cnab.'/'.$banco.'/'.$this->layout_versao.'/'.$filename.'.yml';
+        }
 
         if(!file_exists($filenamePadrao) && !file_exists($filenameEspecifico))
             throw new \Exception('Arquivo não encontrado '. $filename);

--- a/src/Cnab/Format/YamlLoad.php
+++ b/src/Cnab/Format/YamlLoad.php
@@ -6,10 +6,9 @@ use Cnab\Factory;
 class YamlLoad
 {
     public $codigo_banco = null;
-    public $layout_versao = null;
     public $formatPath;
 
-    public function __construct($codigo_banco, $layout_versao = null)
+    public function __construct($codigo_banco)
     {
         $this->codigo_banco = $codigo_banco;
         $this->formatPath = Factory::getCnabFormatPath();
@@ -96,10 +95,12 @@ class YamlLoad
         $filenamePadrao = $this->formatPath.'/'.$cnab.'/generic/'.$filename.'.yml';
         $filenameEspecifico = $this->formatPath.'/'.$cnab.'/'.$banco.'/'.$filename.'.yml';
 
-        if($this->layout_versao != null)
+        $layout_versao = Factory::getLayoutVersao();
+
+        if($layout_versao != null)
         {
             // Usado quando o banco possuir mais de uma versao de Layout
-            $filenameEspecifico = $this->formatPath.'/'.$cnab.'/'.$banco.'/'.$this->layout_versao.'/'.$filename.'.yml';
+            $filenameEspecifico = $this->formatPath.'/'.$cnab.'/'.$banco.'/'.$layout_versao.'_'.$filename.'.yml';
         }
 
         if(!file_exists($filenamePadrao) && !file_exists($filenameEspecifico))

--- a/src/Cnab/Retorno/Cnab240/Arquivo.php
+++ b/src/Cnab/Retorno/Cnab240/Arquivo.php
@@ -11,13 +11,14 @@ class Arquivo implements \Cnab\Retorno\IArquivo
 	public $trailer  = false;
 
 	public $codigo_banco;
+    public $layout_versao;
 
 	private $filename;
 
 	public function __construct($codigo_banco, $filename)
 	{
 		$this->filename = $filename;
-        $layout_versao = Factory::getLayoutVersao($this->filename);
+        $this->layout_versao = Factory::getLayoutVersao($this->filename);
 
 		if(!file_exists($this->filename))
 			throw new \Exception("Arquivo não encontrado: {$this->filename}");

--- a/src/Cnab/Retorno/Cnab240/Arquivo.php
+++ b/src/Cnab/Retorno/Cnab240/Arquivo.php
@@ -1,5 +1,6 @@
 <?php
 namespace Cnab\Retorno\Cnab240;
+use Cnab\Factory;
 
 class Arquivo implements \Cnab\Retorno\IArquivo
 {
@@ -16,6 +17,10 @@ class Arquivo implements \Cnab\Retorno\IArquivo
 	public function __construct($codigo_banco, $filename)
 	{
 		$this->filename = $filename;
+        
+        $layout_versao = Factory::getLayoutVersao($this->filename);
+        Factory::setLayoutVersao($layout_versao);
+
 
 		if(!file_exists($this->filename))
 			throw new \Exception("Arquivo não encontrado: {$this->filename}");

--- a/src/Cnab/Retorno/Cnab240/Arquivo.php
+++ b/src/Cnab/Retorno/Cnab240/Arquivo.php
@@ -17,10 +17,7 @@ class Arquivo implements \Cnab\Retorno\IArquivo
 	public function __construct($codigo_banco, $filename)
 	{
 		$this->filename = $filename;
-        
         $layout_versao = Factory::getLayoutVersao($this->filename);
-        Factory::setLayoutVersao($layout_versao);
-
 
 		if(!file_exists($this->filename))
 			throw new \Exception("Arquivo não encontrado: {$this->filename}");


### PR DESCRIPTION
Criei uma nova opção para definir o layout de arquivo para o mesmo banco, como por exemplo a CEF que tem dois formatos diferentes para o CNAB 240 o SIGCB ou SICOB, neste caso ele lê o arquivo de retorno e pelo número da versão do layout ele sabe qual o formato correto a usar.

Como já funcionava para o SICOB enviei outro pull com o layout do SIGCB compatível com este pull request.

Espero ter ajudado.
Abraços.