### PR TITLE
Identificação de Entrega do Boleto

### DIFF
--- a/src/Cnab/Remessa/Cnab240/Arquivo.php
+++ b/src/Cnab/Remessa/Cnab240/Arquivo.php
@@ -146,6 +146,7 @@ class Arquivo implements \Cnab\Remessa\IArquivo
         $detalhe->segmento_p->prazo_protesto = 0;
         $detalhe->segmento_p->codigo_baixa = 1; // Baixar
         $detalhe->segmento_p->prazo_baixa = 30; // Baixar automaticamente após 30 dias
+        $detalhe->segmento_p->identificacao_distribuicao = $boleto['identificacao_distribuicao'];
 
         if($tipo == 'remessa') {
             $detalhe->segmento_p->codigo_ocorrencia = 1;

--- a/src/Cnab/Remessa/Cnab240/Arquivo.php
+++ b/src/Cnab/Remessa/Cnab240/Arquivo.php
@@ -146,7 +146,9 @@ class Arquivo implements \Cnab\Remessa\IArquivo
         $detalhe->segmento_p->prazo_protesto = 0;
         $detalhe->segmento_p->codigo_baixa = 1; // Baixar
         $detalhe->segmento_p->prazo_baixa = 30; // Baixar automaticamente após 30 dias
-        $detalhe->segmento_p->identificacao_distribuicao = $boleto['identificacao_distribuicao'];
+
+        if (array_key_exists('identificacao_distribuicao', $boleto))
+            $detalhe->segmento_p->identificacao_distribuicao = $boleto['identificacao_distribuicao'];
 
         if($tipo == 'remessa') {
             $detalhe->segmento_p->codigo_ocorrencia = 1;


### PR DESCRIPTION
A identificação de entrega do boleto (identificacao_distribuicao do Segmento P) é necessária na homologação da Caixa