### PR TITLE
Acerto no nome do banco CEF e tratamento para protesto

### DIFF
--- a/src/Cnab/Banco.php
+++ b/src/Cnab/Banco.php
@@ -25,7 +25,7 @@ class Banco
         } elseif ($codigo == self::CEF) {
             return array(
                 'codigo_do_banco' => self::CEF,
-                'nome_do_banco' => 'C ECON FEDERAL',
+                'nome_do_banco' => 'CAIXA ECONOMICA FEDERAL',
             );
         } elseif ($codigo == self::SANTANDER) {
             return array(

--- a/src/Cnab/Format/Identifier.php
+++ b/src/Cnab/Format/Identifier.php
@@ -16,6 +16,8 @@ class Identifier
 
         $contents = \file_get_contents($filename);
 
+        $contents = str_replace("\r\n", "\n", $contents);
+
         $lines = \explode("\n", $contents);
 
         if (\count($lines) < 2) {

--- a/src/Cnab/Remessa/Cnab240/Arquivo.php
+++ b/src/Cnab/Remessa/Cnab240/Arquivo.php
@@ -253,8 +253,14 @@ class Arquivo implements \Cnab\Remessa\IArquivo
         }
         $detalhe->segmento_p->valor_abatimento = 0;
         $detalhe->segmento_p->uso_empresa = $boleto['numero_documento'];
-        $detalhe->segmento_p->codigo_protesto = 3; // 3 = Não protestar
-        $detalhe->segmento_p->prazo_protesto = 0;
+
+        if (!empty($boleto['codigo_protesto']) && !empty($boleto['prazo_protesto'])) {
+            $detalhe->segmento_p->codigo_protesto = $boleto['codigo_protesto'];
+            $detalhe->segmento_p->prazo_protesto = $boleto['prazo_protesto'];
+        } else {
+            $detalhe->segmento_p->codigo_protesto = 3; // 3 = Não protestar
+            $detalhe->segmento_p->prazo_protesto = 0;
+        }
 
         if ($this->codigo_banco == \Cnab\Banco::BANCO_DO_BRASIL) {
             // Campo não tratado pelo sistema. Informar 'zeros'.

--- a/src/Cnab/Remessa/Cnab240/Arquivo.php
+++ b/src/Cnab/Remessa/Cnab240/Arquivo.php
@@ -248,7 +248,7 @@ class Arquivo implements \Cnab\Remessa\IArquivo
             $dateJurosMora->modify('+1 day');
         }
 
-        $detalhe->segmento_p->data_juros_mora = $dateVencimento;
+        $detalhe->segmento_p->data_juros_mora = $dateJurosMora;
 
         $detalhe->segmento_p->valor_juros_mora = $boleto['juros_de_um_dia'];
         if ($boleto['valor_desconto'] > 0) {

--- a/src/Cnab/Remessa/Cnab240/Arquivo.php
+++ b/src/Cnab/Remessa/Cnab240/Arquivo.php
@@ -193,6 +193,7 @@ class Arquivo implements \Cnab\Remessa\IArquivo
     {
         $dateVencimento = $boleto['data_vencimento'] instanceof \DateTime ? $boleto['data_vencimento'] : new \DateTime($boleto['data_vencimento']);
         $dateCadastro = $boleto['data_cadastro'] instanceof \DateTime ? $boleto['data_cadastro'] : new \DateTime($boleto['data_cadastro']);
+        $dateJurosMora = clone $dateVencimento;
 
         $detalhe = new Detalhe($this);
 
@@ -240,7 +241,15 @@ class Arquivo implements \Cnab\Remessa\IArquivo
         $detalhe->segmento_p->aceite = $boleto['aceite'];
         $detalhe->segmento_p->data_emissao = $dateCadastro;
         $detalhe->segmento_p->codigo_juros_mora = 1; // 1 = Por dia
+
+        if (!empty($boleto['dias_iniciar_contagem_juros']) && is_numeric($boleto['dias_iniciar_contagem_juros'])) {
+            $dateJurosMora->modify("+{$boleto['dias_iniciar_contagem_juros']} days");
+        } else {
+            $dateJurosMora->modify('+1 day');
+        }
+
         $detalhe->segmento_p->data_juros_mora = $dateVencimento;
+
         $detalhe->segmento_p->valor_juros_mora = $boleto['juros_de_um_dia'];
         if ($boleto['valor_desconto'] > 0) {
             $detalhe->segmento_p->codigo_desconto_1 = 1; // valor fixo

--- a/tests/Cnab/Remessa/Cnab240/BancoDoBrasilTest.php
+++ b/tests/Cnab/Remessa/Cnab240/BancoDoBrasilTest.php
@@ -64,6 +64,8 @@ class BancoDoBrasilTest extends \PHPUnit_Framework_TestCase
             'mensagem' => 'Descrição do boleto',
             'data_multa' => new \DateTime('2015-02-07'), // data da multa
             'valor_multa' => 11.2, // valor da multa
+            'baixar_apos_dias' => 30,
+            'dias_iniciar_contagem_juros' => 1,
         ));
 
         $texto = $arquivo->getText();
@@ -168,7 +170,7 @@ class BancoDoBrasilTest extends \PHPUnit_Framework_TestCase
                 '109:109' => 'N', // aceite 
                 '110:117' => '14012015', // data_emissao 
                 '118:118' => '1', // codigo_juros_mora 
-                '119:126' => '03022015', // data_juros_mora 
+                '119:126' => '04022015', // data_juros_mora
                 '127:141' => '000000000000010', // valor_juros_mora 
                 '142:142' => '1', // codigo_desconto_1 
                 '143:150' => '09022015', // data_desconto_1 

--- a/tests/Cnab/Remessa/Cnab240/CaixaTest.php
+++ b/tests/Cnab/Remessa/Cnab240/CaixaTest.php
@@ -117,7 +117,7 @@ class CaixaTest extends \PHPUnit_Framework_TestCase
                 '18:18' => '2', // codigo_inscricao 
                 '19:33' => '011222333444455', // numero_inscricao 
                 '34:39' => '123123', // codigo_convenio 
-                '40:53' => '              ', // uso_exclusivo_banco 
+                '40:53' => '00000000000000', // uso_exclusivo_banco
                 '54:58' => '01234', // agencia 
                 '59:59' => '3', // agencia_dv 
                 '60:65' => '123123', // codigo_cedente 

--- a/tests/Cnab/Remessa/Cnab240/CaixaTest.php
+++ b/tests/Cnab/Remessa/Cnab240/CaixaTest.php
@@ -62,6 +62,7 @@ class CaixaTest extends \PHPUnit_Framework_TestCase
             'data_multa' => new \DateTime('2015-02-07'), // data da multa
             'valor_multa' => 11.2, // valor da multa
             'baixar_apos_dias' => 30,
+            'dias_iniciar_contagem_juros' => 1,
         ));
 
         $texto = $arquivo->getText();
@@ -161,7 +162,7 @@ class CaixaTest extends \PHPUnit_Framework_TestCase
                 '109:109' => 'N', // aceite 
                 '110:117' => '14012015', // data_emissao 
                 '118:118' => '1', // codigo_juros_mora 
-                '119:126' => '03022015', // data_juros_mora 
+                '119:126' => '04022015', // data_juros_mora
                 '127:141' => '000000000000010', // valor_juros_mora 
                 '142:142' => '1', // codigo_desconto_1 
                 '143:150' => '09022015', // data_desconto_1 

--- a/tests/Cnab/Remessa/Cnab240/CaixaTest.php
+++ b/tests/Cnab/Remessa/Cnab240/CaixaTest.php
@@ -92,7 +92,7 @@ class CaixaTest extends \PHPUnit_Framework_TestCase
                 '65:71' => '0000000', // uso_exclusivo_caixa_02 
                 '72:72' => '0', // uso_exclusivo_caixa_03 
                 '73:102' => 'Nome Fantasia da sua empresa  ', // nome_empresa 
-                '103:132' => 'C ECON FEDERAL                ', // nome_banco 
+                '103:132' => 'CAIXA ECONOMICA FEDERAL       ', // nome_banco
                 '133:142' => '          ', // uso_exclusivo_febraban_02 
                 '143:143' => '1', // codigo_remessa_retorno 
                 '144:151' => '01022015', // data_geracao 


### PR DESCRIPTION
Realização de acerto no nome do banco da CAIXA.
Adição de tratamento para realização de protesto e dias para protestar.