### PR TITLE
Alteração de variavel repetida

### DIFF
--- a/src/Cnab/Remessa/Cnab400/Arquivo.php
+++ b/src/Cnab/Remessa/Cnab400/Arquivo.php
@@ -144,7 +144,9 @@ class Arquivo implements \Cnab\Remessa\IArquivo
                ocorrência 35 – Cancelamento de Instrução e 38 – Cedente não concorda com alegação do sacado. Para
                os demais códigos de ocorrência este campo deverá ser preenchido com zeros.
             */
-            $detalhe->uso_empresa = $boleto['nosso_numero'];
+            $detalhe->uso_empresa = isset($boleto['uso_empresa']) 
+                                  ? $boleto['uso_empresa'] 
+                                  : $boleto['nosso_numero'];
             $detalhe->nosso_numero = $boleto['nosso_numero'];
 
             $detalhe->numero_carteira = $boleto['carteira'];


### PR DESCRIPTION
Com esta alteração da pra usar o campo uso_empresa, cuja informação não é consistida pelo banco, e não
sai no aviso de cobrança, retornando ao beneficiário no arquivo retorno em qualquer movimento do título
(baixa, liquidação, confirmação de protesto, etc.) com o mesmo conteúdo da entrada.