### PR TITLE
Ajuste de códigos de retorno que estão sendo inicializados com "0" fa…

### DIFF
--- a/src/Cnab/Retorno/Cnab400/Detalhe.php
+++ b/src/Cnab/Retorno/Cnab400/Detalhe.php
@@ -341,23 +341,23 @@ class Detalhe extends \Cnab\Format\Linha implements \Cnab\Retorno\IDetalhe
                 return 'Cancelamento dos dados do rateio';
             }
         } elseif (\Cnab\Banco::CEF == $this->_codigo_banco) {
-            if (01 == $codigo) {
+            if (1 == $codigo) {
                 return 'Entrada Confirmada';
-            } elseif ('02' == $codigo) {
+            } elseif (2 == $codigo) {
                 return 'Baixa Confirmada';
-            } elseif ('03' == $codigo) {
+            } elseif (3 == $codigo) {
                 return 'Abatimento Concedido';
-            } elseif ('04' == $codigo) {
+            } elseif (4 == $codigo) {
                 return 'Abatimento Cancelado';
-            } elseif ('05' == $codigo) {
+            } elseif (5 == $codigo) {
                 return 'Vencimento Alterado';
-            } elseif ('06' == $codigo) {
+            } elseif (6 == $codigo) {
                 return 'Uso da Empresa Alterado';
-            } elseif ('07' == $codigo) {
+            } elseif (7 == $codigo) {
                 return 'Prazo de Protesto Alterado';
-            } elseif ('08' == $codigo) {
+            } elseif (8 == $codigo) {
                 return 'Prazo de Devolução Alterado';
-            } elseif ('09' == $codigo) {
+            } elseif (9 == $codigo) {
                 return 'Alteração Confirmada';
             } elseif (10 == $codigo) {
                 return 'Alteração com Reemissão de Bloqueto Confirmada';

--- a/src/Cnab/Retorno/Cnab400/Detalhe.php
+++ b/src/Cnab/Retorno/Cnab400/Detalhe.php
@@ -343,21 +343,21 @@ class Detalhe extends \Cnab\Format\Linha implements \Cnab\Retorno\IDetalhe
         } elseif (\Cnab\Banco::CEF == $this->_codigo_banco) {
             if (01 == $codigo) {
                 return 'Entrada Confirmada';
-            } elseif (02 == $codigo) {
+            } elseif ('02' == $codigo) {
                 return 'Baixa Confirmada';
-            } elseif (03 == $codigo) {
+            } elseif ('03' == $codigo) {
                 return 'Abatimento Concedido';
-            } elseif (04 == $codigo) {
+            } elseif ('04' == $codigo) {
                 return 'Abatimento Cancelado';
-            } elseif (05 == $codigo) {
+            } elseif ('05' == $codigo) {
                 return 'Vencimento Alterado';
-            } elseif (06 == $codigo) {
+            } elseif ('06' == $codigo) {
                 return 'Uso da Empresa Alterado';
-            } elseif (07 == $codigo) {
+            } elseif ('07' == $codigo) {
                 return 'Prazo de Protesto Alterado';
-            } elseif (08 == $codigo) {
+            } elseif ('08' == $codigo) {
                 return 'Prazo de Devolução Alterado';
-            } elseif (09 == $codigo) {
+            } elseif ('09' == $codigo) {
                 return 'Alteração Confirmada';
             } elseif (10 == $codigo) {
                 return 'Alteração com Reemissão de Bloqueto Confirmada';


### PR DESCRIPTION
No PHP7, números octais são iniciados com "0". no processamento do detalhe, para o banco CEF, os códigos de retorno estão sendo comparados com "inteiros" iniciados com 0. Ajustada a comparação.

PHP 7.0.8-0ubuntu0.16.04.3 (cli) ( NTS )