### PR TITLE
[REMESSA] Juros diários: não tem como informar o código de juros mora…

### DIFF
--- a/src/Cnab/Remessa/Cnab240/Arquivo.php
+++ b/src/Cnab/Remessa/Cnab240/Arquivo.php
@@ -240,7 +240,7 @@ class Arquivo implements \Cnab\Remessa\IArquivo
         $detalhe->segmento_p->especie = $boleto['especie']; // 4 = Duplicata serviço
         $detalhe->segmento_p->aceite = $boleto['aceite'];
         $detalhe->segmento_p->data_emissao = $dateCadastro;
-        $detalhe->segmento_p->codigo_juros_mora = 1; // 1 = Por dia
+        $detalhe->segmento_p->codigo_juros_mora = isset($boleto['codigo_juros_mora'])?$boleto['codigo_juros_mora']:1; // 1 = Por dia, 2= Taxa Mensal, 3= Isento
 
         if (!empty($boleto['dias_iniciar_contagem_juros']) && is_numeric($boleto['dias_iniciar_contagem_juros'])) {
             $dateJurosMora->modify("+{$boleto['dias_iniciar_contagem_juros']} days");

--- a/tests/Cnab/Remessa/Cnab240/BancoDoBrasilTest.php
+++ b/tests/Cnab/Remessa/Cnab240/BancoDoBrasilTest.php
@@ -58,7 +58,8 @@ class BancoDoBrasilTest extends \PHPUnit_Framework_TestCase
             'sacado_uf' => 'BA',
             'data_vencimento' => new \DateTime('2015-02-03'),
             'data_cadastro' => new \DateTime('2015-01-14'),
-            'juros_de_um_dia' => 0.10, // Valor do juros de 1 dia'
+            'codigo_juros_mora' => 2, //‘1’ = Valor por Dia, ‘2’ = Taxa Mensal, ‘3’ = Isento
+            'juros_de_um_dia' => 0.10, // Valor de 1 dia ou taxa do juros de 1 mês
             'data_desconto' => new \DateTime('2015-02-09'),
             'valor_desconto' => 10.0, // Valor do desconto
             'prazo' => 10, // prazo de dias para o cliente pagar após o vencimento


### PR DESCRIPTION
… #132

Olá,

Há um problema ao informar a taxa de juros na remessa.

PROBLEMA 1: TAXA DE JUROS MORA

=> COMO ESTÁ ATUALMENTE?
No arquivo 'src/Cnab/Remessa/Cnab240/Arquivo.php' linha 243 está definido que o campo codigo_juros_mora será 1 ($detalhe->segmento_p->codigo_juros_mora = 1; // 1 = Por dia)

Esse campo pode ser configurado de 3 formas:

‘1’ = Valor por Dia
‘2’ = Taxa Mensal
‘3’ = Isento
=> O PROBLEMA

Quando tenho um boleto com valor inferior a R$30,00 e taxa de juros mensal de 1%(máximo permitido por lei) não será cobrado taxa nenhuma. Veja o calculo de um boleto de R$ 25,00
Formula:
VALOR_JUROS = (VALOR_BOLETO * PERCENTUAL) / 30 //30 é a quantidade de dias do mês padrão

VALOR_JUROS=(25,00*0.01)/30=0,0083
O arquivo de remessa considera apenas duas casas decimais. Sendo assim, o valor de juros será 0,00. Ou seja, o boleto será registrado sem juros nenhum.

O ideal nesse caso seria disponibilizar a opção de informar outro código de juros(o 2, por exemplo) referente a percentual. Assim, o calculo seria feito pelo banco.